### PR TITLE
py3-compatible encoding/decoding dance in slugify

### DIFF
--- a/yewdoc.py
+++ b/yewdoc.py
@@ -66,8 +66,8 @@ def slugify(value):
     and converts spaces to hyphens.
     """
     import unicodedata
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
-    value = unicode(re.sub('[^\w\s-]', '', value).strip().lower())
+    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode()
+    value = re.sub('[^\w\s-]', '', value).strip().lower()
     #... re.sub('[-\s]+', '-', value)
     value = '-'.join(value.split()).lower()
     return value


### PR DESCRIPTION
The current slugify code is incompatible with Python 3 because of it calling unicode. This patch should address the issue though it may still not work with ASCII-incompatible default encodings.